### PR TITLE
Add utility function to compute model's receptive field

### DIFF
--- a/torch_summary.py
+++ b/torch_summary.py
@@ -147,7 +147,8 @@ def print_FOV(model, input_size, device=torch.device('cuda:0'), dtypes=None, ups
                 return
             k = np.array(module.kernel_size)
             s = np.array(module.stride)
-            res['r'] += (k - 1) * res['j']
+            d = np.array(module.dilation)
+            res['r'] += (k - 1) * res['j'] * d
             res['j'] *= s
 
     # multiple inputs to the network


### PR DESCRIPTION
Compute receptive field of a convolutional network, stopping when encountering upsampling layer.

Usage:
```python
import torch
from unet import UNet3D


device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
model = UNet3D(3, 3, num_encoding_blocks=3, padding=1).to(device)
model.eval()
print_FOV(model, (3, 64, 64, 64), device=device)
```