### PR TITLE
Split jobs

### DIFF
--- a/segmentation/run_model.py
+++ b/segmentation/run_model.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 import nibabel as nib
 import torchio
-import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from segmentation.utils import to_var, summary, save_checkpoint, to_numpy
 
@@ -35,7 +34,7 @@ class RunModel:
     def __init__(self, model, device, train_loader, val_loader, val_set,
                  test_set, image_key_name, label_key_name, labels,
                  logger, debug_logger, results_dir, batch_size,
-                 patch_size, struct, eval_results_dir):
+                 patch_size, struct):
         self.model = model
         self.device = device
 
@@ -51,7 +50,6 @@ class RunModel:
         self.logger = logger
         self.debug_logger = debug_logger
         self.results_dir = results_dir
-        self.eval_results_dir = eval_results_dir
 
         self.batch_size = batch_size
         self.patch_size = patch_size
@@ -70,6 +68,7 @@ class RunModel:
         self.metrics = struct['validation']['reporting_metrics']
         self.patch_overlap = struct['validation']['patch_overlap']
         self.save_predictions = struct['validation']['save_predictions']
+        self.eval_results_dir = struct['validation']['eval_results_dir']
         self.n_epochs = struct['n_epochs']
         self.seed = struct['seed']
         self.activation = struct['activation']

--- a/segmentation/run_model.py
+++ b/segmentation/run_model.py
@@ -400,7 +400,8 @@ class RunModel:
         if self.model.training:
             mode = 'Train'
         else:
-            df = pd.DataFrame()
+            if self.eval_results_dir != self.results_dir:
+                df = pd.DataFrame()
             mode = 'Val' if is_batch else 'Whole_image'
 
         shape = targets.shape
@@ -600,7 +601,7 @@ class RunModel:
 
         mode = 'Train' if self.model.training else 'Val'
 
-        if mode == 'Val':
+        if self.eval_results_dir != self.results_dir:
             df = pd.DataFrame()
 
         location = sample.get('index_ini')

--- a/segmentation/run_model.py
+++ b/segmentation/run_model.py
@@ -408,9 +408,10 @@ class RunModel:
         location = sample.get('index_ini')
         affine = sample[self.image_key_name]['affine']
         if is_batch:
-            affine = affine[0]
-        aa = affine[:3, :3]
-        voxel_size = torch.prod(torch.sqrt(torch.sum(aa*aa, dim=0)))
+            affine = to_numpy(affine[0])
+        # M is the product between a scaling and a rotation
+        M = affine[:3, :3]
+        voxel_size = np.diagonal(np.sqrt(M @ M.T)).prod()
 
         batch_size = shape[0]
 
@@ -695,5 +696,5 @@ class RunModel:
                 resdir = f'{self.eval_results_dir}/{name}/'
                 if not os.path.isdir(resdir):
                     os.makedirs(resdir)
-                filename = f'{resdir}/{name}/eval.csv'
+                filename = f'{resdir}/eval.csv'
         df.to_csv(filename)

--- a/segmentation/segmentation_pipeline.py
+++ b/segmentation/segmentation_pipeline.py
@@ -58,10 +58,6 @@ if __name__ == "__main__":
                              'saved according to this configuration file')
     parser.add_argument('-gs', '--grid_search_file', type=str,
                         help='Grid search file')
-    parser.add_argument('-er', '--eval_results_dir', type=str, default=None,
-                        help='Path to eval results directory if it does not '
-                             'start with the config file dir is prepend.'
-                             'If None, results_dir is used.')
     parser.add_argument('-ms', '--max_subjects_per_job', type=int, default=None,
                         help='Maximum number of subjects per job.')
     args = parser.parse_args()
@@ -74,7 +70,6 @@ if __name__ == "__main__":
     extra_file = args.extra_file
     gs_file = args.grid_search_file
     create_jobs_file = args.create_jobs_file
-    eval_results_dir = args.eval_results_dir
 
     jobs, jobs_struct = [], {}
 
@@ -93,22 +88,12 @@ if __name__ == "__main__":
         if os.path.dirname(gs_file) == '':
             gs_file = os.path.join(os.path.dirname(file), gs_file)
 
-        if eval_results_dir is None:
-            eval_results_dir = ''
-        else:
-            if os.path.dirname(eval_results_dir) == '':
-                eval_results_dir = os.path.join(
-                    os.path.dirname(file), eval_results_dir)
+        gs_struct = parse_grid_search_file(gs_file)
 
-        gs_struct = parse_grid_search_file(gs_file, eval_results_dir)
-
-        for results_dir, eval_results_dir, values in zip(
-                gs_struct['results_dirs'],
-                gs_struct['eval_results_dirs'],
-                gs_struct['values']
+        for results_dir, values in zip(
+                gs_struct['results_dirs'], gs_struct['values']
         ):
             results_dir = handle_results_dir(results_dir, file)
-            eval_results_dir = handle_results_dir(eval_results_dir, file)
             logger = instantiate_logger(
                 f'info_{results_dir}', logging.INFO, results_dir + '/info.txt')
             debug_logger = instantiate_logger(
@@ -117,7 +102,7 @@ if __name__ == "__main__":
             config = Config(file, results_dir, logger, debug_logger, args.mode,
                             args.visualization, extra_file, args.safe_mode,
                             args.create_jobs_file, gs_struct['keys'], values,
-                            eval_results_dir, args.max_subjects_per_job)
+                            args.max_subjects_per_job)
             result = config.run()
             if result is not None:
                 jobs += result
@@ -138,7 +123,6 @@ if __name__ == "__main__":
         config = Config(file, results_dir, logger, debug_logger, args.mode,
                         args.visualization, extra_file, args.safe_mode,
                         args.create_jobs_file,
-                        eval_results_dir=eval_results_dir,
                         max_subjects_per_job=args.max_subjects_per_job)
         result = config.run()
         if result is not None:

--- a/segmentation/segmentation_pipeline.py
+++ b/segmentation/segmentation_pipeline.py
@@ -62,6 +62,8 @@ if __name__ == "__main__":
                         help='Path to eval results directory if it does not '
                              'start with the config file dir is prepend.'
                              'If None, results_dir is used.')
+    parser.add_argument('-ms', '--max_subjects_per_job', type=int, default=None,
+                        help='Maximum number of subjects per job.')
     args = parser.parse_args()
 
     rlimit = resource.getrlimit(resource.RLIMIT_NOFILE)
@@ -89,7 +91,7 @@ if __name__ == "__main__":
 
     if gs_file is not None:
         if os.path.dirname(gs_file) == '':
-            grid_search_file = os.path.join(os.path.dirname(file), gs_file)
+            gs_file = os.path.join(os.path.dirname(file), gs_file)
 
         if eval_results_dir is None:
             eval_results_dir = ''
@@ -115,8 +117,10 @@ if __name__ == "__main__":
             config = Config(file, results_dir, logger, debug_logger, args.mode,
                             args.visualization, extra_file, args.safe_mode,
                             args.create_jobs_file, gs_struct['keys'], values,
-                            eval_results_dir)
-            jobs.append(config.run())
+                            eval_results_dir, args.max_subjects_per_job)
+            result = config.run()
+            if result is not None:
+                jobs += result
 
     else:
         if extra_file is not None:
@@ -133,8 +137,12 @@ if __name__ == "__main__":
 
         config = Config(file, results_dir, logger, debug_logger, args.mode,
                         args.visualization, extra_file, args.safe_mode,
-                        args.create_jobs_file)
-        jobs.append(config.run())
+                        args.create_jobs_file,
+                        eval_results_dir=eval_results_dir,
+                        max_subjects_per_job=args.max_subjects_per_job)
+        result = config.run()
+        if result is not None:
+            jobs += result
 
     if create_jobs_file is not None:
         jobs_struct['jobs'] = jobs


### PR DESCRIPTION
Enable to split evaluation between jobs by specifying a maximum number of subjects per job. Add also the possibility to specify the evaluation result directory which will be used to save CSV files and predicted volumes.