### PR TITLE
Add options to apply band and far mask before computing metrics

### DIFF
--- a/segmentation/README.md
+++ b/segmentation/README.md
@@ -325,7 +325,9 @@ is saved after every evaluation loop on the validation set,
             "mask_cut": [0.99, 1],                      // Thresholds used for the mask
             "binarize_target": false,                   // If target should be binarized
             "binarize_prediction": false,               // If prediction should be binarized
-            "binary_volumes": false                     // If prediction and target are given as binary label maps
+            "binary_volumes": false,                    // If prediction and target are given as binary label maps
+            "band_width": null,                         // If not null, width (in voxel) of the mask around the target volume binarized above lower bound of "mask_cut"
+            "use_far_mask": false                       // If mask of points further than the band mask should be applied
             // "activation": {...}                      // Activation function, default uses the model activation function
         }
     ], 

--- a/segmentation/config.py
+++ b/segmentation/config.py
@@ -526,6 +526,9 @@ class Config:
                 self.set_struct_value(criterion, 'binary_volumes', False)
                 self.set_struct_value(criterion, 'activation', activation)
                 self.set_struct_value(criterion, 'weight', 1)
+                self.set_struct_value(criterion, 'band_width')
+                self.set_struct_value(criterion, 'pv_threshold', 0.01)
+                self.set_struct_value(criterion, 'use_far_mask', False)
                 self.set_struct_value(
                     criterion, 'reported_name',
                     f'{criterion["name"]}_{criterion["method"]}')
@@ -551,7 +554,10 @@ class Config:
                         binarize_target=criterion['binarize_target'],
                         activation=a,
                         binary_volumes=criterion['binary_volumes'],
-                        binarize_prediction=criterion['binarize_prediction']
+                        binarize_prediction=criterion['binarize_prediction'],
+                        band_width=criterion['band_width'],
+                        pv_threshold=criterion['pv_threshold'],
+                        use_far_mask=criterion['use_far_mask']
                     ),
                     'weight': criterion['weight'],
                     'name': criterion['reported_name']


### PR DESCRIPTION
Add options to compute metrics on new masks:
- on all points with partial volume lower than a given threshold and closer than a given distance to the partial volume map bigger than the chosen threshold.
- on all points further than a given distance to the partial volume map bigger than the chosen threshold.

![image](https://user-images.githubusercontent.com/39873986/94276618-c705dd80-ff48-11ea-8dc7-d24ec74a3e51.png)
First column the GM partial volume map, second column shows GM > 0.01, the third one shows the band mask with a distance of 3 voxels, last column shows the mask where points are further than 3 voxels away.