### PR TITLE
add_dict_normalization_csv_reader

### DIFF
--- a/read_csv_results.py
+++ b/read_csv_results.py
@@ -136,6 +136,15 @@ class ModelCSVResults(object):
             trsfm_composition = Compose(trsfm_list)
             return trsfm_composition, trsfm_seeds
 
+    def normalize_dict_to_df(self, col, suffix=None):
+        if suffix is None:
+            suffix = col
+        dict_vals = self.df_data[col].apply(json.loads)
+        val_names = dict_vals[0].keys()
+        for name in val_names:
+            self.df_data[f"{suffix}_{name}"] = dict_vals.apply(lambda x: x[name])
+        return self.df_data
+
     def extract_from_history(self, col, key, save_csv=False, col_name=None):
         data_col = self.df_data[~self.df_data[col].isnull()][col]
         dict_data = data_col.apply(lambda x: json.loads(x)[key])


### PR DESCRIPTION
Salut,

ajout de la méthode `normalize_dict_to_df` pour la classe `ModelCSVResults` du fichier read_csv_results. Elle permet d'extraire toutes les clés/valeurs d'une colonne contenant des dictionnaires pour les mettre sous forme de colonne dans la DataFrame